### PR TITLE
Fix on the code that detects RFC proxies

### DIFF
--- a/src/grst_canl_x509.c
+++ b/src/grst_canl_x509.c
@@ -1752,7 +1752,7 @@ int GRSTx509MakeProxyCert(char **proxychain, FILE *debugfp,
     /* TODO MP is this necessary? caNl test if new proxy timeout
      * is longer than signer cert proxy timeout */
     for (i=1; i < ncerts; ++i)
-        if (X509_get_ext_by_OBJ(certs[i], pci_obj, -1) > 0) 
+        if (X509_get_ext_by_OBJ(certs[i], pci_obj, -1) > -1) 
             any_rfc_proxies = 1;
 
    /* if any earlier proxies are RFC 3820, then new proxy must be 


### PR DESCRIPTION
Hi,

The current code base of Gridsite fails to detect an RFC proxy if the extension is at position 0.
You can compare with the code from [voms](https://github.com/italiangrid/voms/blob/ae3dea43f377a893449ac973e3d2cf09ff73cd88/src/utils/voms_proxy_info.cc#L339)

Because of this, invalid proxy credentials are generated under certain circumstances (see [FTS-220](https://its.cern.ch/jira/browse/FTS-220))

Best regards,
Alejandro Álvarez Ayllón
