### PR TITLE
Allow / in libdir

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -351,7 +351,7 @@ gridsite-storage.cgi: gridsite-storage.lo libgridsite.la
             -lgridsite $(CURL_LIBS)
 
 %.pc: %.pc.in
-	sed -e "s/@version@/$(VERSION)/" -e "s,@prefix@,$(prefix)," -e "s/@libdir@/$(libdir)/" $< > $@
+	sed -e "s/@version@/$(VERSION)/" -e "s,@prefix@,$(prefix)," -e "s,@libdir@,$(libdir)," $< > $@
 
 clean:
 	rm -rvf doxygen


### PR DESCRIPTION
I was playing around with implementing multilib support on debian, and setting libdir=lib/$(DEB_HOST_MULTIARCH) didn't work, because the slash screwed up the sed command.