### PR TITLE
No xml2-config

### DIFF
--- a/doc/findproxyfile.1
+++ b/doc/findproxyfile.1
@@ -52,7 +52,7 @@ form /tmp/x509up_uUID as well.
 If a proxy is found, its full path is output on standard out.
 
 .SH EXIT CODES
-0 is returned on succcess. Non-zero otherwise.
+0 is returned on success. Non-zero otherwise.
 
 .SH BUGS
 In this version, no attempt is made to verify or validate the proxies.

--- a/src/Makefile
+++ b/src/Makefile
@@ -54,8 +54,8 @@ endif
 
 CURL_CFLAGS=`curl-config --cflags`
 CURL_LIBS=`curl-config --libs`
-XML2_CFLAGS=`xml2-config --cflags`
-XML2_LIBS=`xml2-config --libs`
+XML2_CFLAGS=`pkg-config libxml-2.0 --cflags`
+XML2_LIBS=`pkg-config libxml-2.0 --libs`
 HTTPD_FLAGS=-I/usr/include/httpd -I/usr/include/apache2 -I/usr/include/apr-0 -I/usr/include/apr-1 -I/usr/include/apr-1.0
 GSOAP_CFLAGS=`pkg-config gsoap --cflags`
 GSOAP_LIBS=`pkg-config gsoap --libs`


### PR DESCRIPTION
The next version of libxml2 will no longer ship the xml2-config script in Debian. This changes gridsit to use pkg-config libxml-2.0 instead.
    
See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=949154
