### PR TITLE
Fix build with doxygen 1.14 and later

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -282,7 +282,7 @@ apidoc:
 	date
 	doxygen Doxyfile
 	mkdir -p ../doc/doxygen
-	cp -f doxygen/*.html doxygen/*.css doxygen/*.png ../doc/doxygen
+	cp -f doxygen/* ../doc/doxygen
 	cd ../doc ; for i in *.1 *.8 ; do ../src/roffit < $$i \
           > $$i.html ; done
 


### PR DESCRIPTION
The build script explicitly selects which files created by doxygen that should be copied to the installed documentation by listing specific file types: *.html *.css *.png.

The latest versions of doxygen do not create any *.png files when using the gridsite Doxyfile. It does however produce a few *.js files and a *.svg file. Since there are no *.png files created the build fails:
```
mkdir -p ../doc/doxygen
cp -f doxygen/*.html doxygen/*.css doxygen/*.png ../doc/doxygen
cp: cannot stat 'doxygen/*.png': No such file or directory
make[2]: *** [Makefile:285: apidoc] Error 1
```
This commit changes the copy statement to copy all files regardless of file type, so that it works with any version of doxygen.

This build failure was reported to both RedHat bugzilla and Debian BTS:
- https://bugzilla.redhat.com/show_bug.cgi?id=2385037
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1122423